### PR TITLE
Fix test for new binary structure.

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -44,7 +44,7 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter.nodeConverter;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
-import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isNonRdfSourceDescription;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isFedoraBinary;
 import static org.fcrepo.kernel.modeshape.utils.FedoraSessionUserUtil.USER_AGENT_BASE_URI_PROPERTY;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -83,8 +83,8 @@ import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
-import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.services.NodeService;
+import org.fcrepo.kernel.modeshape.FedoraBinaryImpl;
 import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 import org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter;
 import org.fcrepo.kernel.modeshape.rdf.impl.DefaultIdentifierTranslator;
@@ -196,8 +196,8 @@ public class WebACRolesProvider implements AccessRolesProvider {
 
         // Get the effective ACL by searching the target node and any ancestors.
         final Optional<ACLHandle> effectiveAcl = getEffectiveAcl(
-                isNonRdfSourceDescription.test(getJcrNode(resource)) ?
-                    ((NonRdfSourceDescription)nodeConverter.convert(getJcrNode(resource))).getDescribedResource() :
+                isFedoraBinary.test(getJcrNode(resource)) ? ((FedoraBinaryImpl) nodeConverter.convert(
+                        getJcrNode(resource))).getDescription() :
                     resource);
 
         // Construct a list of acceptable acl:accessTo values for the target resource.

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -462,7 +462,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("FAILING")
     public void testAccessToBinary() throws IOException {
         // Block access to "book"
         final String idBook = "/rest/book";


### PR DESCRIPTION
**JIRA Ticket**: 

# What does this Pull Request do?

We used to check for the `NonRdfSourceDescription` and the locate the binary from there, now we find the binary and `getDescription()` to get the `NonRdfSourceDescription`.

This changes the check and alters the logic to still return the description in the case of a `FedoraBinary`

@peichman-umd 
