### PR TITLE
Allow DELETE {} INSERT {...}, Disallow DELETE DATA {...}

### DIFF
--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -1022,6 +1022,20 @@ public class WebACRecipesIT extends AbstractResourceIT {
             logger.debug("Testing SPARQL update: {}", query);
             assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(patchReq));
         }
+        final String[] allowedDeleteSPARQLQueries = new String[] {
+            "DELETE DATA {}",
+            "DELETE { } WHERE {}",
+            "DELETE { } INSERT {} WHERE {}"
+        };
+        for (final String query : allowedDeleteSPARQLQueries) {
+            final HttpPatch patchReq = new HttpPatch(testObj);
+            setAuth(patchReq, username);
+            patchReq.setEntity(new StringEntity(query));
+            patchReq.setHeader("Content-Type", "application/sparql-update");
+            logger.debug("Testing SPARQL update: {}", query);
+            assertEquals(HttpStatus.SC_NO_CONTENT, getStatus(patchReq));
+        }
+
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2857

# What does this Pull Request do?
Adjusts the `hasDeleteClause` test to only count a delete clause that specifies a quad and include Delete Data clauses with at least one quad. 

# What's new?
Changes and adds some test cases that are now allowed.

# How should this be tested?

Internal tests but essentially with acl:Append permissions you
* Can't `DELETE { ... } INSERT { ... } WHERE { ... }`
* Can `DELETE {} INSERT { ... } WHERE { ... }`
* Can't `DELETE DATA { ... }`
* Can `DELETE DATA {}`

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@peichman-umd 
